### PR TITLE
feat: add alphabetical ordering

### DIFF
--- a/src/main/java/br/com/mercadolivre/desafiospring/controller/ProductController.java
+++ b/src/main/java/br/com/mercadolivre/desafiospring/controller/ProductController.java
@@ -4,13 +4,17 @@ import br.com.mercadolivre.desafiospring.dto.request.ProductDTO;
 import br.com.mercadolivre.desafiospring.models.Product;
 import br.com.mercadolivre.desafiospring.services.ProductService;
 import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/")
@@ -24,4 +28,12 @@ public class ProductController {
         return productService.addProducts(product.dtoToModel());
     }
 
+    @GetMapping("articles")
+    public List<Product> retrieveSortedProducts(@RequestParam("order") Optional<Integer> orderStrategy) throws IOException {
+        if (orderStrategy.isPresent()) {
+            return productService.sortProducts(orderStrategy.get());
+        }
+        // depends on #7
+        return new ArrayList<>();
+    }
 }

--- a/src/main/java/br/com/mercadolivre/desafiospring/services/ProductService.java
+++ b/src/main/java/br/com/mercadolivre/desafiospring/services/ProductService.java
@@ -2,6 +2,8 @@ package br.com.mercadolivre.desafiospring.services;
 
 import br.com.mercadolivre.desafiospring.models.Product;
 import br.com.mercadolivre.desafiospring.repository.ApplicationRepository;
+import br.com.mercadolivre.desafiospring.strategies.AlphabeticalOrdering;
+import br.com.mercadolivre.desafiospring.strategies.OrderingStrategy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +19,18 @@ public class ProductService {
     public List<Product> addProducts(List<Product> products) throws IOException {
         repo.add(products);
 
+        return products;
+    }
+
+    public List<Product> retrieveOrderedProducts(int orderStrategy) throws IOException {
+
+        List<Product> products = repo.read();
+
+        if (orderStrategy == 0) {
+            return new AlphabeticalOrdering().sortAsc(products);
+        } else if (orderStrategy == 1) {
+            return new AlphabeticalOrdering().sortDesc(products);
+        }
         return products;
     }
 }

--- a/src/main/java/br/com/mercadolivre/desafiospring/services/ProductService.java
+++ b/src/main/java/br/com/mercadolivre/desafiospring/services/ProductService.java
@@ -21,7 +21,7 @@ public class ProductService {
         return products;
     }
 
-    public List<Product> sortProducts(int sortStrategy) throws IOException {
+    public List<Product> sortProducts(Integer sortStrategy) throws IOException {
 
         List<Product> products = repo.read();
 

--- a/src/main/java/br/com/mercadolivre/desafiospring/services/ProductService.java
+++ b/src/main/java/br/com/mercadolivre/desafiospring/services/ProductService.java
@@ -21,10 +21,6 @@ public class ProductService {
         return products;
     }
 
-    public List<Product> readAllProducts() throws IOException {
-        return repo.read();
-    }
-
     public List<Product> sortProducts(int sortStrategy) throws IOException {
 
         List<Product> products = repo.read();

--- a/src/main/java/br/com/mercadolivre/desafiospring/services/ProductService.java
+++ b/src/main/java/br/com/mercadolivre/desafiospring/services/ProductService.java
@@ -2,8 +2,7 @@ package br.com.mercadolivre.desafiospring.services;
 
 import br.com.mercadolivre.desafiospring.models.Product;
 import br.com.mercadolivre.desafiospring.repository.ApplicationRepository;
-import br.com.mercadolivre.desafiospring.strategies.AlphabeticalOrdering;
-import br.com.mercadolivre.desafiospring.strategies.OrderingStrategy;
+import br.com.mercadolivre.desafiospring.strategies.AlphabeticalSort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,14 +21,18 @@ public class ProductService {
         return products;
     }
 
-    public List<Product> retrieveOrderedProducts(int orderStrategy) throws IOException {
+    public List<Product> readAllProducts() throws IOException {
+        return repo.read();
+    }
+
+    public List<Product> sortProducts(int sortStrategy) throws IOException {
 
         List<Product> products = repo.read();
 
-        if (orderStrategy == 0) {
-            return new AlphabeticalOrdering().sortAsc(products);
-        } else if (orderStrategy == 1) {
-            return new AlphabeticalOrdering().sortDesc(products);
+        if (sortStrategy == 0) {
+            return new AlphabeticalSort().sortAsc(products);
+        } else if (sortStrategy == 1) {
+            return new AlphabeticalSort().sortDesc(products);
         }
         return products;
     }

--- a/src/main/java/br/com/mercadolivre/desafiospring/strategies/AlphabeticalSort.java
+++ b/src/main/java/br/com/mercadolivre/desafiospring/strategies/AlphabeticalSort.java
@@ -1,0 +1,23 @@
+package br.com.mercadolivre.desafiospring.strategies;
+
+import br.com.mercadolivre.desafiospring.models.Product;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AlphabeticalSort implements SortStrategy<Product> {
+
+    @Override
+    public List<Product> sortAsc(List<Product> productsToSort) {
+        return productsToSort.stream()
+                .sorted((itemX, itemY)-> itemX.getName().compareTo(itemY.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Product> sortDesc(List<Product> products) {
+        return products.stream()
+                .sorted((itemX, itemY)-> itemY.getName().compareTo(itemX.getName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/br/com/mercadolivre/desafiospring/strategies/SortStrategy.java
+++ b/src/main/java/br/com/mercadolivre/desafiospring/strategies/SortStrategy.java
@@ -1,0 +1,10 @@
+package br.com.mercadolivre.desafiospring.strategies;
+
+import java.util.List;
+
+public interface SortStrategy<T>{
+
+    List<T> sortAsc(List<T> listToOrder);
+    List<T> sortDesc(List<T> listToOrder);
+
+}


### PR DESCRIPTION
Implements strategy pattern to allow different sorting of products and also implements alphabetical sorting, both ascending and descending.

I added a route to teste and I was not sure if it's in the scope of this PR, considering that the creation of `/articles` is object of #8. 

----
You can test through this request in postman [GET_SORTED_PRODUCTS](https://galactic-satellite-194316.postman.co/workspace/W5G6---Java-Lee~da556dc7-51a0-4d90-9b1a-74d7a2c4c7a6/request/20170672-b8c5bc1a-5157-43d1-b51b-c9afaeb22902)

or via `sh`

```bash
# asc
curl -X GET 'localhost:8080/api/v1/articles?order=0'
# desc
curl -X GET 'localhost:8080/api/v1/articles?order=1'
```

closes #11 